### PR TITLE
Migrate asset URLs from AWS S3 to Cloudflare R2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Lords of the Pit is a static website for a Chicago-based Old School Magic: the G
 - **3.1GB+ of images** stored directly in git (no LFS)
 - All images in `src/assets/images/`
 - Images are regular git objects (no special setup required)
-- S3 bucket available for PDFs: `https://lordsofthepit.s3.us-east-2.amazonaws.com`
+- R2 bucket available for PDFs: `https://assets.lordsofthepit.com` (migrated from S3 to Cloudflare R2)
 
 ### Writer-Friendly Workflow
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,7 +20,7 @@ export default function (eleventyConfig) {
       "The Lords of the Pit are the United States' premiere Old School Magic: the Gathering club based out of Chicago, IL. Members of this group include current club members ('Lords') as well as prospective new members ('Thrulls').",
     baseurl: '/',
     url: 'https://lordsofthepit.com',
-    s3BucketPrefix: 'https://lordsofthepit.s3.us-east-2.amazonaws.com',
+    s3BucketPrefix: 'https://assets.lordsofthepit.com',
     lang: 'en',
   })
 

--- a/src/posts/2018-08-23-episode-1-pre-ball-cast.md
+++ b/src/posts/2018-08-23-episode-1-pre-ball-cast.md
@@ -6,6 +6,6 @@ date: "2018-08-23"
 category: Pitcast
 ---
 
-<audio controls crossorigin="anonymous" src="https://lordsofthepit.s3.us-east-2.amazonaws.com/pitcast/ep01.mp3"></audio>
+<audio controls crossorigin="anonymous" src="https://assets.lordsofthepit.com/pitcast/ep01.mp3"></audio>
 
 Pull up a chair and slam a drink with the Lords of the Pit. This is a podcast about Old School MtG.


### PR DESCRIPTION
- Replaces direct-S3 references with `https://assets.lordsofthepit.com`
- Covers `eleventy.config.js` (the `s3BucketPrefix` config) and the one hardcoded URL in `src/posts/2018-08-23-episode-1-pre-ball-cast.md`
- Updates `CLAUDE.md` to reflect the new bucket location
- R2 bucket `lordsofthepit` is already provisioned, populated by Super Slurper, and serving via `assets.lordsofthepit.com` (HTTP 200 confirmed on `/pitcast/ep01.mp3`)

Part of consolidating the Northern Information AWS account onto Cloudflare. The legacy S3 sync line is kept commented in `syncUp.sh` (in the separate `intertext` repo) until the AWS bucket is decommissioned during the soak period.